### PR TITLE
[im-t2624]: Add IMT Linux kernel config patch for spi800 support.

### DIFF
--- a/patch/config-im-t2624.patch
+++ b/patch/config-im-t2624.patch
@@ -1,0 +1,33 @@
+From 28e68cbcdacedfaec10a206d262d93bc3ac4bd40 Mon Sep 17 00:00:00 2001
+From: Yurii Hordynskyi <yuriih@interfacemasters.com>
+Date: Mon, 22 Jun 2020 14:27:25 +0000
+Subject: [PATCH] Add smbus/pmbus support for psu (spi800)
+
+Signed-off-by: Yurii Hordynskyi <yuriih@interfacemasters.com>
+---
+ debian/build/build_amd64_none_amd64/.config | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index 3dccd93a..61a2c8b3 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -3949,11 +3949,12 @@ CONFIG_SENSORS_NCT6775=m
+ # CONFIG_SENSORS_NCT7802 is not set
+ # CONFIG_SENSORS_NCT7904 is not set
+ CONFIG_SENSORS_PCF8591=m
+-CONFIG_PMBUS=m
+-CONFIG_SENSORS_PMBUS=m
++CONFIG_PMBUS=y
++CONFIG_SENSORS_PMBUS=y
+ # CONFIG_SENSORS_ADM1275 is not set
+ CONFIG_SENSORS_LM25066=m
+-# CONFIG_SENSORS_LTC2978 is not set
++CONFIG_SENSORS_LTC2978=m
++CONFIG_SENSORS_LTC2978_REGULATOR=y
+ # CONFIG_SENSORS_LTC3815 is not set
+ # CONFIG_SENSORS_MAX16064 is not set
+ # CONFIG_SENSORS_MAX20751 is not set
+-- 
+2.17.1
+

--- a/patch/series
+++ b/patch/series
@@ -85,6 +85,7 @@ linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch
 kernel-enable-psample-and-act_sample-drivers.patch
+config-im-t2624.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch


### PR DESCRIPTION
* Add IMT Linux kernel config patch for spi800 support.
* Apply the patch during Linux kernel build.
```
admin@sonic:~$ dmesg
[ 72.425491] i2c i2c-43: new_device: Instantiated device spi800 at 0x58
[ 72.427170] i2c i2c-43: new_device: Instantiated device spi800 at 0x59

admin@sonic:~$ lsmod | grep spi800
spi800 16384 0
```